### PR TITLE
Fix extracting templates in all locales

### DIFF
--- a/lib/runtime
+++ b/lib/runtime
@@ -306,7 +306,7 @@ _extractldif () {
     warn_log "Warning : invalid depth supplied to _extractldif(), using default (2)..."
     _EXTRACTDEPTH='2'
   fi
-  grep "^#\{$_EXTRACTDEPTH\}[^#]*$" "$0" | sed 's|^#*||' 2>>"$LOGFILE"
+  grep -a "^#\{$_EXTRACTDEPTH\}[^#]*$" "$0" | sed 's|^#*||' 2>>"$LOGFILE"
 }
 
 # Filters LDIF information


### PR DESCRIPTION
The special characters are causing grep to detect that the file as
binary under some locales. This causes it output something like Binary
file /usr/share/ldapscripts/runtime matches instead of extracting the
embedded template required for adding users, groups etc. This results in
failure. Adding -a option to grep fixes the issue.

Fixes #3.
