### PR TITLE
Don't attempt to remove a user from an empty list of groups

### DIFF
--- a/sbin/ldapdeleteuser
+++ b/sbin/ldapdeleteuser
@@ -50,7 +50,7 @@ _ldapdelete "$_UDN" || end_die "Error deleting user $_UDN from LDAP"
 case $GCLASS in
   posixGroup)
     _findentries "$GSUFFIX,$SUFFIX" "(&(objectClass=posixGroup)(memberUid=$_UID))"
-    echo "$_ENTRIES" | \
+    [ -n "$_ENTRIES" ] && echo "$_ENTRIES" | \
     while read _ENTRY
     do
       echo_log "Deleting user from secondary group: $_ENTRY"
@@ -60,7 +60,7 @@ case $GCLASS in
   ;;
   *)
     _findentries "$GSUFFIX,$SUFFIX" "(&(objectClass=$GCLASS)($_GMEMBERATTR=$_UDN))"
-    echo "$_ENTRIES" | \
+    [ -n "$_ENTRIES" ] && echo "$_ENTRIES" | \
     while read _ENTRY
     do
       echo_log "Deleting user from secondary group: $_ENTRY"


### PR DESCRIPTION
`ldapdeleteuser` also removes a user from any groups they were in, which is very helpful. However, it attempts to do so even if the user wasn't a member of any groups, resulting in a spurious message about deleting the user from a secondary group with no name. This PR fixes the issue by skipping the `while` loop if the list of groups is empty.