### PR TITLE
First add of .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.patched


### PR DESCRIPTION
Currently only *.patched files are ignored. These are files generated from build via Make, so they should be ignored by git.

This is to ease development and build from source. With this change, the git repo stays clean when `make` is called.