### PR TITLE
Add ldapnextuid executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ SBINFILES =	ldapdeletemachine ldapmodifygroup ldapsetpasswd lsldap ldapadduser \
 			ldapdeleteuser ldapsetprimarygroup ldapfinger ldapid ldapgid ldapmodifymachine \
 			ldaprenamegroup ldapaddgroup ldapaddusertogroup ldapdeleteuserfromgroup \
 			ldapinit ldapmodifyuser ldaprenamemachine ldapaddmachine ldapdeletegroup \
-			ldaprenameuser
+			ldaprenameuser ldapnextuid
 MAN1FILES =	ldapdeletemachine.1 ldapmodifymachine.1 ldaprenamemachine.1 ldapadduser.1 \
 			ldapdeleteuserfromgroup.1 ldapfinger.1 ldapid.1 ldapgid.1 ldapmodifyuser.1 lsldap.1 \
 			ldapaddusertogroup.1 ldaprenameuser.1 ldapinit.1 ldapsetpasswd.1 ldapaddgroup.1 \

--- a/README
+++ b/README
@@ -129,6 +129,7 @@ sbin/ldapsetpasswd : modifies a POSIX user or machine account's password in LDAP
 sbin/ldapfinger : displays a user/machine/group POSIX account's details
 sbin/ldapid : displays a user's list of IDs
 sbin/ldapgid : displays a group's list of IDs
+sbin/ldapnextuid : displays the first available user ID
 
 Environment :
 *************

--- a/sbin/ldapnextuid
+++ b/sbin/ldapnextuid
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#  ldapnextuid : finds the next POSIX UID from LDAP
+
+#  Copyright (C) 2021 Nicolas PEUGNET
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+#  USA.
+
+# Source runtime file
+_RUNTIMEFILE="/usr/lib/ldapscripts/runtime"
+. "$_RUNTIMEFILE"
+
+_findnextuid


### PR DESCRIPTION
It makes the "next user ID from LDAP" accessible from outside the scripts by calling the `_findnextuid` function and displaying its result.


As the group of a user has to be created before the user, I use this script to get the next user ID to be created, and pass it to `ldapaddgroup` to make sure it is the same as the user.
This is because I have some groups in a range above the user's one (this is not ideal but I don't want to change it now).

The material probably isn't worth copyrighting :sweat_smile: but I added it to be on par with the other scripts.

What do you think about adding this script ?